### PR TITLE
actual attribute may exist but may be blank. 

### DIFF
--- a/taskwarrior_time_report/__init__.py
+++ b/taskwarrior_time_report/__init__.py
@@ -95,7 +95,9 @@ def main():
         for task in logged_tasks:
             row = list()
             actual_time = ''
-            if ('m' in task['actual']):
+            if not ('actual' in task):
+                continue
+            elif ('m' in task['actual']):
                 # Convert to hours
                 actual_time = float(int(task['actual'][:task['actual'].index('m')])) / 60
             elif ('h' in task['actual']):


### PR DESCRIPTION
Querying `actual.not:empty` does not avoid this. Fixes #2
